### PR TITLE
change: don't fail fast in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
         # Set this to notify the global nur package registry that changes are
         # available.


### PR DESCRIPTION
The nixos-unstable job is currently broken. We want to see if the stable job completes.


partly addresses https://github.com/0xB10C/nix/issues/40