### PR TITLE
add: fork-observer integration test

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,12 @@
           ];
           hostPkgs = import nixpkgs { inherit system; };
         };
+        fork-observer = nixos-lib.runTest {
+          imports = [ 
+            ./tests/fork-observer.nix 
+          ];
+          hostPkgs = import nixpkgs { inherit system; };
+        };
       });
       
     };

--- a/modules/fork-observer/default.nix
+++ b/modules/fork-observer/default.nix
@@ -174,7 +174,7 @@ in {
         type = types.str;
         default = "db";
         example = "db";
-        description = "Name of the sled database folder.";
+        description = "Name of the sqlite database.";
       };
 
       queryInterval = mkOption {

--- a/tests/fork-observer.nix
+++ b/tests/fork-observer.nix
@@ -1,0 +1,121 @@
+{ pkgs, ... }:
+
+let
+
+  BITCOIND_RPC_PORT = 8332;
+  FORK_OBSERVER_PORT = 5432;
+  DB_NAME = "nixos-test.sqlite";
+  ADDRESS = "127.0.0.1:${toString FORK_OBSERVER_PORT}";
+  NETWORK_ID = 1234;
+in {
+  name = "fork-observer";
+
+  nodes.machine = { config, lib, ... }: {
+    imports =
+      [ ../modules/fork-observer/default.nix ];
+
+    virtualisation.cores = 2;
+
+    services.bitcoind."regtest" = {
+      enable = true;
+      extraConfig = ''
+        regtest=1
+        rest=1
+        debug=rpc
+        rpcwhitelist=fork-observer:getchaintips,getblockheader,getblockhash,getblock,getnetworkinfo
+      '';
+      rpc = {
+        port = BITCOIND_RPC_PORT;
+        users.fork-observer = {
+          name = "fork-observer";
+          passwordHMAC =
+            "a086e1c71a326b56b490249203406ad6$30d91b328c812f1faf82783df5388b808b3a91a945a0f8bae071c2bef4549e7e";
+        };
+      };
+    };
+
+    services.fork-observer = {
+      enable = true;
+      databaseName = DB_NAME;
+      queryInterval = 2;
+      footer = "nixos-test footer";
+      rss_base_url = ADDRESS;
+      networks = [
+        {
+          id = NETWORK_ID;
+          name = "nixos-test-network";
+          description = "a test network";
+          minForkHeight = 0;
+          maxInterestingHeights = 25;
+          poolIdentification = {
+            enable = false;
+          };
+          nodes = [
+            {
+              id = 567;
+              name = "Node 567";
+              description = "This is a node.";
+              rpcPort = BITCOIND_RPC_PORT;
+              rpcHost = "127.0.0.1";
+              rpcUser = "fork-observer";
+              rpcPassword = "hunter2";
+              useREST = true;
+              implementation = "BitcoinCore";
+            }
+          ];
+        }
+      ];
+      address = ADDRESS;
+    };
+
+  };
+
+  testScript = ''
+    import time
+    import json
+    
+    machine.systemctl("stop fork-observer.service")
+    
+    machine.wait_for_unit("bitcoind-regtest.service", timeout=15)
+    machine.wait_for_open_port(${toString BITCOIND_RPC_PORT})
+  
+
+    # give bitcoind a bit of time to start up before we hit the RPC interface
+    time.sleep(5)
+    machine.systemctl("start fork-observer.service")
+    
+    # configuration file should have been created
+    config = machine.succeed("cat /etc/fork-observer/config.toml")
+    print("Configuration file:")
+    print(config)
+    
+    machine.wait_for_unit("fork-observer.service", timeout=15)
+    machine.wait_for_open_port(${toString FORK_OBSERVER_PORT})
+
+    # check that the database and the table has been created
+    machine.succeed("${pkgs.sqlite}/bin/sqlite3 /var/lib/fork-observer/${DB_NAME} 'select * from headers limit 1;'")
+
+    networks = machine.succeed("curl ${ADDRESS}/api/networks.json");
+    print("networks.json response", networks)
+    n = json.loads(networks)
+    
+    assert len(n["networks"]) == 1
+    network = n["networks"][0]
+    assert network["id"] == ${toString NETWORK_ID}
+    assert network["name"] == "nixos-test-network"
+    assert network["description"] == "a test network"
+
+    data = machine.succeed("curl ${ADDRESS}/api/${toString NETWORK_ID}/data.json");
+    print("data.json response:", data)
+    d = json.loads(data)
+
+    assert len(d["nodes"]) == 1
+    node = d["nodes"][0]
+    assert node["id"] == 567
+    assert node["name"] == "Node 567"
+    assert node["description"] == "This is a node."
+    assert node["implementation"] == "Bitcoin Core"
+    assert node["reachable"]
+    assert "Satoshi" in node["version"]
+  '';
+}


### PR DESCRIPTION
Tests the module and lightly tests the static parts of the API. No chain tips/headers testing (yet).