### PR TITLE
update: fork-observer

### DIFF
--- a/pkgs/fork-observer/default.nix
+++ b/pkgs/fork-observer/default.nix
@@ -3,18 +3,18 @@
 rustPlatform.buildRustPackage rec {
   pname = "fork-observer";
   name = "fork-observer";
-  version = "104f51f918e4c3a0ad2ec1a3dc83856eef386019";
+  version = "53da2409af4eb1a7717202fbbcb0f768e114c416";
 
   src = pkgs.fetchFromGitHub {
     owner = "0xB10C";
     repo = "fork-observer";
     rev = version;
-    sha256 = "sha256-0KeiOUVTL8zIYKdW+1yU0fWZfgSBoFh88yYOXz/Y7jE=";
+    sha256 = "sha256-u5J1Xw+nbsQh17PV4Q/vLAVjODuzs8qaCExZtlAgwVg=";
   };
 
   nativeBuildInputs = with pkgs; [ sqlite ];
 
-  cargoHash = "sha256-7aM8+8n4u2nFSJrwlYIzgUoy7XFRg//8MazJaSJnoZo=";
+  cargoHash = "sha256-Zc/thU1KnjMUdAjB11rRbd3EQU13kZ2Ly6BRD6GSDmw=";
 
   postInstall = ''
     cp -r www $out/www


### PR DESCRIPTION
for compatabillity with Bitcoin Core 28 (https://github.com/0xB10C/fork-observer/pull/46)