### PR TITLE
fix: no requires in systemd config

### DIFF
--- a/modules/github-metadata-backup/default.nix
+++ b/modules/github-metadata-backup/default.nix
@@ -151,6 +151,7 @@ in {
           "network-online.target"
           "github-metadata-backup-${instanceName}.target"
         ];
+        requires = [ "network-online.target" ];
         wantedBy = [ "github-metadata-backup-${instanceName}.target" ];
         script = ''
           ${cfg.package}/bin/github-metadata-backup \
@@ -193,6 +194,7 @@ in {
           "github-metadata-backup-${instanceName}.target"
           "github-metadata-backup-${instanceName}.service"
         ];
+        requires = [ "network-online.target" ];
         wantedBy = [ "github-metadata-backup-${instanceName}.target" ];
 
         script = ''

--- a/modules/github-metadata-mirror/default.nix
+++ b/modules/github-metadata-mirror/default.nix
@@ -114,6 +114,7 @@ in {
       (nameValuePair "github-metadata-mirror-${instanceName}" ({
         description = "GitHub Metadata Mirror ${instanceName}";
         after = [ "network-online.target" ];
+        requires = [ "network-online.target" ];
         script = ''
           set -e
 


### PR DESCRIPTION
fixes the warning 'service is ordered after 'network-online.target' but doesn't depend on it'