### PR TITLE
change: run peer-observer with a non-root user

### DIFF
--- a/modules/peer-observer/default.nix
+++ b/modules/peer-observer/default.nix
@@ -114,8 +114,8 @@ in {
             "clone3"
             "@debug"
           ];
-          User = "root";
-          Group = "root";
+          User = "peerobserver";
+          Group = "peerobserver";
         };
       };
 


### PR DESCRIPTION
Turns out, CAP_BPF, CAP_PERFMON and CAP_SYS_RESOURCE systemd capabilities for the service are enough to run the peer-observer binary.

Fixes https://github.com/0xB10C/nix/issues/28