### PR TITLE
fix: github-metadata-mirror module

### DIFF
--- a/modules/github-metadata-mirror/default.nix
+++ b/modules/github-metadata-mirror/default.nix
@@ -134,7 +134,7 @@ in {
           cp --recursive --no-preserve=ownership,mode ${cfg.package}/* $WORK_DIR
 
           echo "generate the issue and pull markdown files to the hugo content and data directories from the backup files in ${instanceCfg.backup}"
-          ${pkgs.python3}/bin/python ${cfg.package}/generate-data.py ${instanceCfg.backup} $WORK_DIR
+          ${pkgs.python3}/bin/python ${cfg.package}/generate-data.py ${instanceCfg.backup} $WORK_DIR ${instanceCfg.owner}/${instanceCfg.repository}
 
           echo "do a hugo build of the site"
           ${pkgs.hugo}/bin/hugo --source $WORK_DIR --logLevel debug --baseURL ${instanceCfg.siteBaseURL}


### PR DESCRIPTION
generate-data.py now needs a owner/repository parameter since https://github.com/0xB10C/github-metadata-mirror/pull/3 which was updated to in https://github.com/0xB10C/nix/pull/59/commits/cbdabef3f0c19779adf0d03493e6404b0992b6d4