### PR TITLE
Update peer-observer to NATS message queue instead of nng message queue

### DIFF
--- a/modules/peer-observer/default.nix
+++ b/modules/peer-observer/default.nix
@@ -21,11 +21,12 @@ in {
 
       extractor = {
         enable = mkEnableOption "peer-observer extractor";
-        eventsAddress = mkOption {
+        
+        natsAddress = mkOption {
           type = types.str;
-          default = "tcp://127.0.0.1:8883";
-          example = "tcp://127.0.0.1:8883";
-          description = "Address the extractor publishes events on";
+          default = "127.0.0.1:4222";
+          example = "127.0.0.1:4222";
+          description = "Address of the NATS server the extractor publishes events to";
         };
         
         bitcoindPath = mkOption {
@@ -122,7 +123,7 @@ in {
       startLimitIntervalSec = 120;
       serviceConfig =
         {
-          ExecStart = "${cfg.package}/bin/extractor --bitcoind-path ${cfg.extractor.bitcoindPath} --bitcoind-pid-file ${cfg.extractor.bitcoindPIDFile} --libbpf-debug --address ${cfg.extractor.eventsAddress} ${cfg.extractor.extraArgs}";
+          ExecStart = "${cfg.package}/bin/extractor --bitcoind-path ${cfg.extractor.bitcoindPath} --bitcoind-pid-file ${cfg.extractor.bitcoindPIDFile} --libbpf-debug --nats-address ${cfg.extractor.natsAddress} ${cfg.extractor.extraArgs}";
           Restart = "always";
           # restart every 30 seconds but fail if we do more than 3 restarts in 120 sec
           RestartSec = 30;
@@ -153,7 +154,7 @@ in {
         wants = ["network-online.target" "peer-observer-extractor.service" ];
         startLimitIntervalSec = 120;
         serviceConfig = {
-          ExecStart = "${cfg.package}/bin/metrics --address ${cfg.extractor.eventsAddress} --metrics-address ${cfg.metrics.metricsAddress}";
+          ExecStart = "${cfg.package}/bin/metrics --nats-address ${cfg.extractor.natsAddress} --metrics-address ${cfg.metrics.metricsAddress}";
           Environment = "RUST_LOG=info";
           Restart = "always";
           # restart every 30 seconds. Limit this to 3 times in 'startLimitIntervalSec'
@@ -176,7 +177,7 @@ in {
         wants = ["network-online.target" "peer-observer-extractor.service" ];
         startLimitIntervalSec = 120;
         serviceConfig = {
-          ExecStart = "${cfg.package}/bin/connectivity-check --address ${cfg.extractor.eventsAddress} --metrics-address ${cfg.addrConnectivity.metricsAddress}";
+          ExecStart = "${cfg.package}/bin/connectivity-check --nats-address ${cfg.extractor.natsAddress} --metrics-address ${cfg.addrConnectivity.metricsAddress}";
           Environment = "RUST_LOG=info";
           Restart = "always";
           # restart every 30 seconds. Limit this to 3 times in 'startLimitIntervalSec'
@@ -201,7 +202,7 @@ in {
         wants = ["network-online.target" "peer-observer-extractor.service" ];
         startLimitIntervalSec = 120;
         serviceConfig = {
-          ExecStart = "${cfg.package}/bin/websocket --address ${cfg.extractor.eventsAddress} --websocket-address ${cfg.websocket.websocketAddress}";
+          ExecStart = "${cfg.package}/bin/websocket --nats-address ${cfg.extractor.natsAddress} --websocket-address ${cfg.websocket.websocketAddress}";
           Environment = "RUST_LOG=info";
           Restart = "always";
           # restart every 30 seconds. Limit this to 3 times in 'startLimitIntervalSec'

--- a/pkgs/peer-observer/default.nix
+++ b/pkgs/peer-observer/default.nix
@@ -2,13 +2,13 @@
 
 rustPlatform.buildRustPackage rec {
   name = "peer-observer";
-  version = "e4a7b9f333d05db33f2add392a9a47a121ed8de6";
+  version = "002bd683baaaeaa0bc20d87a2e715d35aef06bb4";
   
   src = pkgs.fetchFromGitHub {
     owner = "0xB10C";
     repo = "peer-observer";
     rev = version;
-    sha256 = "sha256-gOEKaE49mN/4+//zJ4EJKzAGMfKjyP7jQXPnOVeNjI0=";
+    sha256 = "sha256-0McsEbtij0pNvuYuaCaCIenYq7om3LSNL1oK9ne4bCo=";
   };
 
   hardeningDisable = [
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
     pkgs.rustfmt
   ];
 
-  cargoHash = "sha256-z99cSIsBwPy2KkMMih+JjjPYC05E33o+CAiUZaZOraA=";
+  cargoHash = "sha256-kw+ZLxqEYMhrCPHlanbX1hDABnfddtUhvK3gQ0gzaYw=";
 
   meta = with stdenv.lib; {
     description = "Hooks into Bitcoin Core to observe how our peers interact with us.";

--- a/pkgs/peer-observer/default.nix
+++ b/pkgs/peer-observer/default.nix
@@ -2,13 +2,13 @@
 
 rustPlatform.buildRustPackage rec {
   name = "peer-observer";
-  version = "5caba4376cdd02468c06dba2a15946b1178b754c";
+  version = "e4a7b9f333d05db33f2add392a9a47a121ed8de6";
   
   src = pkgs.fetchFromGitHub {
     owner = "0xB10C";
     repo = "peer-observer";
     rev = version;
-    sha256 = "sha256-FptRQK1TY55HXBbpaDxZ22OXPNMjrygy+L8x1jKKq0k=";
+    sha256 = "sha256-gOEKaE49mN/4+//zJ4EJKzAGMfKjyP7jQXPnOVeNjI0=";
   };
 
   hardeningDisable = [
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
     pkgs.rustfmt
   ];
 
-  cargoHash = "sha256-t/dQZehgsTlb2LXY93738JgCTwYOof70Upx+3Z/MZec=";
+  cargoHash = "sha256-z99cSIsBwPy2KkMMih+JjjPYC05E33o+CAiUZaZOraA=";
 
   meta = with stdenv.lib; {
     description = "Hooks into Bitcoin Core to observe how our peers interact with us.";


### PR DESCRIPTION
As part of https://github.com/0xB10C/peer-observer/issues/56