### PR TITLE
add: esplora support for fork-observer module

### DIFF
--- a/modules/fork-observer/default.nix
+++ b/modules/fork-observer/default.nix
@@ -108,13 +108,13 @@ let
       };
 
       rpcUser = mkOption {
-        type = types.str;
+        type = types.nullOr types.str;
         default = null;
         description = "Bitcoin Core RPC server user";
       };
 
       rpcPassword = mkOption {
-        type = types.str;
+        type = types.nullOr types.str;
         default = null;
         description = "Bitcoin Core RPC server password";
       };
@@ -134,7 +134,7 @@ let
       };
 
       implementation = mkOption {
-        type = types.enum [ "BitcoinCore" "btcd" ];
+        type = types.enum [ "BitcoinCore" "btcd" "esplora" ];
         default = "BitcoinCore";
         description = "The Bitcoin implementation to query";
       };
@@ -151,8 +151,8 @@ let
     # TODO: rpc_cookie_file = "~/.bitcoin/.cookie"
     rpc_host = "${node.rpcHost}"
     rpc_port = ${toString node.rpcPort}
-    rpc_user = "${node.rpcUser}"
-    rpc_password = "${node.rpcPassword}"
+    ${optionalString (node.rpcUser != null) "rpc_user = \"${node.rpcUser}\""}
+    ${optionalString (node.rpcPassword != null) "rpc_password = \"${node.rpcPassword}\""}
     use_rest = ${boolToString node.useREST}
     implementation = "${node.implementation}"
 

--- a/tests/fork-observer.nix
+++ b/tests/fork-observer.nix
@@ -62,6 +62,26 @@ in {
               useREST = true;
               implementation = "BitcoinCore";
             }
+            {
+              id = 568;
+              name = "esplora";
+              description = "This is using the esplora backend";
+              rpcPort = BITCOIND_RPC_PORT;
+              rpcHost = "https://esplora.example.com/api";
+              useREST = true;
+              implementation = "esplora";
+            }
+            {
+              id = 569;
+              name = "btcd";
+              description = "This is a btcd node.";
+              rpcPort = 12345;
+              rpcHost = "127.0.0.1";
+              rpcUser = "fork-observer";
+              rpcPassword = "hunter2";
+              useREST = false;
+              implementation = "btcd";
+            }
           ];
         }
       ];
@@ -109,7 +129,7 @@ in {
     print("data.json response:", data)
     d = json.loads(data)
 
-    assert len(d["nodes"]) == 1
+    assert len(d["nodes"]) == 3
     node = d["nodes"][0]
     assert node["id"] == 567
     assert node["name"] == "Node 567"


### PR DESCRIPTION
Adds the implementation "esplora" and allows rpcUser and rpcPassword to be `null` 