### PR TITLE
add: build on ubuntu-24.04-arm for aarch64 pkgs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,10 @@ jobs:
         nixPath:
           - nixpkgs=channel:nixos-unstable
           - nixpkgs=channel:nixos-24.11
-    runs-on: ubuntu-latest
+        runsOn:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+    runs-on: "${{ matrix.runsOn }}"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
With the hope that this prefills the cache with aarch64 pkgs