### PR TITLE
ci: run when someone is (un)assigned

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,10 @@
 name: "Build and populate cache"
 on:
   workflow_dispatch:
+  # To be able to trigger a rebuild manually by (un)assigning someone
+  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request
   pull_request:
+    types: [opened, reopened, synchronize, assigned, unassigned]
   push:
     branches:
       - main


### PR DESCRIPTION
This allows for quicker runs of auto updated PRs by assigning someone instead of closing and reopening the PR.