### PR TITLE
ci: first integration test and then build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,13 @@ jobs:
           --drv-path --show-trace \
           -I nixpkgs=$(nix-instantiate --find-file nixpkgs) \
           -I $PWD
-    - name: Build nix packages
-      run: nix-build --max-jobs 1
+    # run integration tests before we run the build since we need to build
+    # the package anyway for the integration tests. So a build failure is
+    # detected anyway.
     - name: Run NixOS module integration tests
       # We can't run the module integration tests on ARM due to the runners not having kvm enabled
       # error: a 'aarch64-linux' with features {kvm, nixos-test} is required to build '/nix/store/hk46b962dbx*-vm-test-run-*.drv', but I am a 'aarch64-linux' with features {benchmark, big-parallel, nixos-test, uid-range}
       if: matrix.runsOn == 'ubuntu-latest'
       run: nix flake check --print-build-logs --max-jobs 1
+    - name: Build nix packages
+      run: nix-build --max-jobs 1


### PR DESCRIPTION
run integration tests before we run the build since we need to build the package anyway for the integration tests. So a build failure is detected. This allows us to reuse the integration test packages in the package build phase, so it speeds up CI.