### PR TITLE
fix eval error, attribute values are nested under tools

### DIFF
--- a/modules/peer-observer/default.nix
+++ b/modules/peer-observer/default.nix
@@ -140,7 +140,7 @@ in {
 
     };
   };
-  config = mkIf (cfg.extractors.ebpf.enable || cfg.metrics.enable || cfg.addrConnectivity.enable || cfg.websocket.enable) {
+  config = mkIf (cfg.extractors.ebpf.enable || cfg.tools.metrics.enable || cfg.tools.addrConnectivity.enable || cfg.tools.websocket.enable) {
     users = {
       users.peerobserver = { isSystemUser = true; group = "peerobserver"; };
       groups.peerobserver = { };

--- a/modules/peer-observer/default.nix
+++ b/modules/peer-observer/default.nix
@@ -140,7 +140,7 @@ in {
 
     };
   };
-  config = mkIf (cfg.extractors.ebpf.enable || cfg.tools.metrics.enable || cfg.tools.addrConnectivity.enable || cfg.tools.websocket.enable) {
+  config = mkIf (cfg.extractors.ebpf.enable || cfg.extractors.rpc.enable || cfg.tools.metrics.enable || cfg.tools.addrConnectivity.enable || cfg.tools.websocket.enable) {
     users = {
       users.peerobserver = { isSystemUser = true; group = "peerobserver"; };
       groups.peerobserver = { };


### PR DESCRIPTION
fixes eval error if you have `extractors.ebpf.enable = false`. Seems correct everywhere else in the file.