### PR TITLE
update: peer-observer clang_14 -> clang_18

### DIFF
--- a/pkgs/peer-observer/default.nix
+++ b/pkgs/peer-observer/default.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
     pkgs.cmake
 
     # for building libbpf
-    pkgs.clang_14
+    pkgs.clang_18
     pkgs.pkg-config
 
     # needed for libbpf-cargo


### PR DESCRIPTION
as clang_14 is removed in NixOS unstable

See https://github.com/0xB10C/nix/actions/runs/17820692524/job/50662368526#step:8:191

    error: clang_14 has been removed, as it is unmaintained and obsolete