### PR TITLE
build: fix flake build on darwin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,12 +22,15 @@ jobs:
         runsOn:
           - ubuntu-latest
           - ubuntu-24.04-arm
+          - macos-26-intel
+          - macos-26
     runs-on: "${{ matrix.runsOn }}"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
     - run: df -h
     - name: free up disk space
+      if: ${{ !startsWith(matrix.runsOn, 'macos-') }}
       run: |
         sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
         sudo docker image prune --all --force

--- a/default.nix
+++ b/default.nix
@@ -1,18 +1,24 @@
 { pkgs ? import <nixpkgs> { } }:
-
-{
-  addrman-observer = pkgs.callPackage ./pkgs/addrman-observer { };
-  asmap-data = pkgs.callPackage ./pkgs/asmap-data { };
-  bitcoind-tracing-v28 = pkgs.callPackage ./pkgs/bitcoind-tracing { version = "v28.0"; };
-  bitcoind-tracing-v29 = pkgs.callPackage ./pkgs/bitcoind-tracing { version = "v29.0"; useCmake = true; };
-  bitcoind-tracing-v30 = pkgs.callPackage ./pkgs/bitcoind-tracing { version = "v30.0"; useCmake = true; };
-  ckpool = pkgs.callPackage ./pkgs/ckpool { };
-  discourse-archive = pkgs.callPackage ./pkgs/discourse-archive { };
-  fork-observer = pkgs.callPackage ./pkgs/fork-observer { };
-  github-metadata-backup = pkgs.callPackage ./pkgs/github-metadata-backup { };
-  github-metadata-mirror = pkgs.callPackage ./pkgs/github-metadata-mirror { };
-  stratum-observer = pkgs.callPackage ./pkgs/stratum-observer { };
-  miningpool-observer = pkgs.callPackage ./pkgs/miningpool-observer { };
-  peer-observer = pkgs.callPackage ./pkgs/peer-observer { };
-  mainnet-observer-backend = (pkgs.callPackage ./pkgs/mainnet-observer { }).backend;
-}
+let
+  linuxOnlyPkgs = pkgs.lib.attrsets.optionalAttrs pkgs.stdenv.hostPlatform.isLinux
+    {
+      # TODO: These aren't strictly linux-specific, but the build is failing on darwin.
+      ckpool = pkgs.callPackage ./pkgs/ckpool { };
+      stratum-observer = pkgs.callPackage ./pkgs/stratum-observer { };
+      mainnet-observer-backend = (pkgs.callPackage ./pkgs/mainnet-observer { }).backend;
+    };
+  allPlatformsPkgs = {
+    addrman-observer = pkgs.callPackage ./pkgs/addrman-observer { };
+    asmap-data = pkgs.callPackage ./pkgs/asmap-data { };
+    bitcoind-tracing-v28 = pkgs.callPackage ./pkgs/bitcoind-tracing { version = "v28.0"; };
+    bitcoind-tracing-v29 = pkgs.callPackage ./pkgs/bitcoind-tracing { version = "v29.0"; useCmake = true; };
+    bitcoind-tracing-v30 = pkgs.callPackage ./pkgs/bitcoind-tracing { version = "v30.0"; useCmake = true; };
+    discourse-archive = pkgs.callPackage ./pkgs/discourse-archive { };
+    fork-observer = pkgs.callPackage ./pkgs/fork-observer { };
+    github-metadata-backup = pkgs.callPackage ./pkgs/github-metadata-backup { };
+    github-metadata-mirror = pkgs.callPackage ./pkgs/github-metadata-mirror { };
+    miningpool-observer = pkgs.callPackage ./pkgs/miningpool-observer { };
+    peer-observer = pkgs.callPackage ./pkgs/peer-observer { };
+  };
+in
+  allPlatformsPkgs // linuxOnlyPkgs

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
         "i686-linux"
         "x86_64-darwin"
         "aarch64-linux"
+        "aarch64-darwin"
         "armv6l-linux"
         "armv7l-linux"
       ];

--- a/pkgs/bitcoind-tracing/default.nix
+++ b/pkgs/bitcoind-tracing/default.nix
@@ -10,6 +10,7 @@
 , capnproto
 , version
 , useCmake ? false
+, enableTracing ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isStatic
 , ...
 }:
 
@@ -35,15 +36,18 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     (if useCmake then cmake else autoreconfHook)
-    libsystemtap
-  ] ++ lib.optionals needsCapnp [ capnproto ];
-  buildInputs = [ boost libevent libsystemtap ];
+  ] ++ lib.optionals needsCapnp [ capnproto ]
+    ++ lib.optionals enableTracing [ libsystemtap ];
+  buildInputs = [
+    boost
+    libevent
+  ] ++ lib.optionals enableTracing [ libsystemtap ];
 
   cmakeFlags = if useCmake then [
     (lib.cmakeBool "BUILD_BENCH" false)
     (lib.cmakeBool "WITH_ZMQ" false)
     (lib.cmakeBool "WITH_BDB" false)
-    (lib.cmakeBool "WITH_USDT" true)
+    (lib.cmakeBool "WITH_USDT" enableTracing)
     (lib.cmakeBool "BUILD_TESTS" false)
     (lib.cmakeBool "BUILD_FUZZ_BINARY" false)
     (lib.cmakeBool "BUILD_GUI_TESTS" false)
@@ -58,8 +62,7 @@ stdenv.mkDerivation rec {
     "--disable-bench"
     "--disable-tests"
     "--enable-fuzz-binary=no"
-    "--enable-ebpf"
-  ];
+  ] ++ lib.optionals enableTracing [ "--enable-ebpf" ];
 
   doCheck = false;
   enableParallelBuilding = true;

--- a/pkgs/peer-observer/default.nix
+++ b/pkgs/peer-observer/default.nix
@@ -1,4 +1,10 @@
-{ stdenv, pkgs, rustPlatform, ... }:
+{ stdenv
+, lib
+, pkgs
+, rustPlatform
+, enableTracing ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isStatic
+, ...
+}:
 
 rustPlatform.buildRustPackage rec {
   name = "peer-observer";
@@ -17,42 +23,45 @@ rustPlatform.buildRustPackage rec {
     "fortify"
   ];
 
-  buildInputs = [
-    # for building libbpf
-    pkgs.elfutils
-    pkgs.zlib
+  buildInputs = with pkgs; [
+    zlib
+  ] ++ lib.optionals enableTracing [
+    elfutils
   ];
 
-  nativeBuildInputs = [
-    pkgs.protobuf
-    pkgs.cmake
-
-    # for building libbpf
-    pkgs.llvmPackages_20.clang-unwrapped
-    pkgs.pkg-config
-
-    # needed for libbpf-cargo
-    pkgs.rustfmt
+  nativeBuildInputs = with pkgs; [
+    protobuf
+    cmake
+  ] ++ lib.optionals enableTracing [
+    llvmPackages_20.clang-unwrapped
+    pkg-config
+    rustfmt
   ];
 
-  # during the integration tests, don't try to download a bitcoind binary
-  # use the nix one instead
-  BITCOIND_SKIP_DOWNLOAD = "1";
-  BITCOIND_EXE = "${pkgs.bitcoind}/bin/bitcoind";
-  # Overwrite the default `cargo check` with `cargo test --all-features`
-  # to run the integration tests.
-  checkPhase = ''
-    export NATS_SERVER_BINARY="${pkgs.nats-server}/bin/nats-server"
-    cargo test --all-features
-  '';
+  cargoBuildFlags = lib.optionals (!enableTracing) [
+      "--workspace --exclude ebpf-extractor"
+  ];
 
-  # set the path of the Linux kernel headers. These are needed in
-  # build.rs of the ebpf-extractor on Nix.
-  KERNEL_HEADERS = "${pkgs.linuxHeaders}/include";
+  cargoTestFlags = [
+    "--all-features"
+  ] ++ lib.optionals (!enableTracing) [
+      "--workspace --exclude ebpf-extractor"
+  ] ++ lib.optionals (pkgs.stdenv.hostPlatform.isDarwin) [
+      "--exclude log-extractor"
+  ];
 
   cargoHash = "sha256-eJFW1gX2RKdVE73t1VxhyfPO9oz+tqHrAfFASNbySoY=";
 
-  meta = with stdenv.lib; {
+  # Set the path of the Linux kernel headers for the ebpf-extractor.
+  KERNEL_HEADERS = lib.derivations.optionalDrvAttr enableTracing 
+    "${pkgs.linuxHeaders}/include";
+
+  # In the integration tests, use the nix bitcoind and nats binaries.
+  BITCOIND_SKIP_DOWNLOAD = "1";
+  BITCOIND_EXE = "${pkgs.bitcoind}/bin/bitcoind";
+  NATS_SERVER_BINARY="${pkgs.nats-server}/bin/nats-server";
+
+  meta = {
     description = "Hooks into Bitcoin Core to observe how our peers interact with us.";
   };
 

--- a/pkgs/peer-observer/default.nix
+++ b/pkgs/peer-observer/default.nix
@@ -61,6 +61,11 @@ rustPlatform.buildRustPackage rec {
   BITCOIND_EXE = "${pkgs.bitcoind}/bin/bitcoind";
   NATS_SERVER_BINARY="${pkgs.nats-server}/bin/nats-server";
 
+  # Avoid RLIMIT_NOFILE=unlimited overflowing to -1 in bitcoind on macOS.
+  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    ulimit -n 1024
+  '';
+
   meta = {
     description = "Hooks into Bitcoin Core to observe how our peers interact with us.";
   };


### PR DESCRIPTION
Fix flake build in darwin architectures that can't handle usdt tracepoints by adding conditional logic to everything that is linux-specific or won't currently build on darwin.

Add darwin runners to CI.

Follow-ups:
1. `log-extractor` integration tests succeed on linux but will fail (hence disabled) on darwin (e.g. see this [ci report](https://github.com/edilmedeiros/nix/actions/runs/23023845300).

<details>

<summary>Relevant logs from a local run</summary>

```
❯ nix build .#peer-observer -L --print-build-logs -v
warning: Git tree '/Users/edil.medeiros/2-development/bitcoin/nix' is dirty
this derivation will be built:
  /nix/store/r9v7cpym5qf6mfsg0q9dq3flg5d6lng7-peer-observer.drv
building '/nix/store/r9v7cpym5qf6mfsg0q9dq3flg5d6lng7-peer-observer.drv'...
peer-observer> Running phase: unpackPhase
peer-observer> unpacking source archive /nix/store/23i15cvfxl89przvjx7gxmifjfswxfqk-source
peer-observer> source root is source
peer-observer> Executing cargoSetupPostUnpackHook
peer-observer> Finished cargoSetupPostUnpackHook
peer-observer> Running phase: patchPhase
peer-observer> Executing cargoSetupPostPatchHook
peer-observer> Validating consistency between /private/tmp/nix-build-peer-observer.drv-0/source/Cargo.lock and /private/tmp/nix-build-peer-observer.drv-0/peer-observer-vendor/Cargo.lock
peer-observer> Finished cargoSetupPostPatchHook
peer-observer> Running phase: updateAutotoolsGnuConfigScriptsPhase
peer-observer> Running phase: configurePhase
peer-observer> Running phase: buildPhase
peer-observer> Executing cargoBuildHook
peer-observer> cargoBuildHook flags: -j 11 --target aarch64-apple-darwin --offline --profile release --workspace --exclude ebpf-extractor
peer-observer>    Compiling proc-macro2 v1.0.84
peer-observer>    Compiling unicode-ident v1.0.11
peer-observer>    Compiling libc v0.2.182
peer-observer>    Compiling serde_core v1.0.228
peer-observer>    Compiling shlex v1.3.0
peer-observer>    Compiling serde v1.0.228
peer-observer>    Compiling cfg-if v1.0.0
peer-observer>    Compiling memchr v2.6.3
peer-observer>    Compiling stable_deref_trait v1.2.0
peer-observer>    Compiling itoa v1.0.9
peer-observer>    Compiling anyhow v1.0.75
peer-observer>    Compiling bitflags v2.4.0
peer-observer>    Compiling pin-project-lite v0.2.14
peer-observer>    Compiling rustix v0.38.44
peer-observer>    Compiling cc v1.2.29
peer-observer>    Compiling litemap v0.7.3
peer-observer>    Compiling writeable v0.5.5
peer-observer>    Compiling futures-core v0.3.31
peer-observer>    Compiling untrusted v0.9.0
peer-observer>    Compiling serde_json v1.0.142
peer-observer>    Compiling ryu v1.0.15
peer-observer>    Compiling arrayvec v0.7.4
peer-observer>    Compiling bitcoin-internals v0.3.0
peer-observer>    Compiling smallvec v1.13.2
peer-observer>    Compiling pkg-config v0.3.30
peer-observer>    Compiling either v1.9.0
peer-observer>    Compiling itertools v0.10.5
peer-observer>    Compiling hex-conservative v0.2.1
peer-observer>    Compiling icu_locid_transform_data v1.5.0
peer-observer>    Compiling ring v0.17.14
peer-observer>    Compiling secp256k1-sys v0.10.0
peer-observer>    Compiling bzip2-sys v0.1.13+1.0.8
peer-observer>    Compiling crc32fast v1.5.0
peer-observer>    Compiling futures-sink v0.3.31
peer-observer>    Compiling bitcoin-io v0.1.2
peer-observer>    Compiling once_cell v1.21.3
peer-observer>    Compiling ppv-lite86 v0.2.17
peer-observer>    Compiling quote v1.0.36
peer-observer>    Compiling getrandom v0.3.3
peer-observer>    Compiling rustix v1.1.2
peer-observer>    Compiling syn v2.0.87
peer-observer>    Compiling hex_lit v0.1.1
peer-observer>    Compiling errno v0.3.13
peer-observer>    Compiling getrandom v0.2.10
peer-observer>    Compiling socket2 v0.6.0
peer-observer>    Compiling mio v1.0.4
peer-observer>    Compiling signal-hook-registry v1.4.5
peer-observer>    Compiling simd-adler32 v0.3.7
peer-observer>    Compiling thiserror v1.0.48
peer-observer>    Compiling rustls-pki-types v1.10.0
peer-observer>    Compiling futures-io v0.3.31
peer-observer>    Compiling adler2 v2.0.1
peer-observer>    Compiling synstructure v0.13.1
peer-observer>    Compiling rustls v0.21.12
peer-observer>    Compiling icu_properties_data v1.5.0
peer-observer>    Compiling miniz_oxide v0.8.9
peer-observer>    Compiling futures-channel v0.3.31
peer-observer>    Compiling thiserror v2.0.12
peer-observer>    Compiling utf16_iter v1.0.5
peer-observer>    Compiling hashbrown v0.14.0
peer-observer>    Compiling log v0.4.29
peer-observer>    Compiling pin-utils v0.1.0
peer-observer>    Compiling icu_normalizer_data v1.5.0
peer-observer>    Compiling autocfg v1.1.0
peer-observer>    Compiling bitcoin v0.32.7
peer-observer>    Compiling write16 v1.0.0
peer-observer>    Compiling core-foundation-sys v0.8.7
peer-observer>    Compiling bytes v1.10.1
peer-observer>    Compiling utf8_iter v1.0.4
peer-observer>    Compiling heck v0.5.0
peer-observer>    Compiling serde_derive v1.0.228
peer-observer>    Compiling zerofrom-derive v0.1.4
peer-observer>    Compiling yoke-derive v0.7.4
peer-observer>    Compiling zerovec-derive v0.10.3
peer-observer>    Compiling displaydoc v0.2.5
peer-observer>    Compiling icu_provider_macros v1.5.0
peer-observer>    Compiling prost-derive v0.14.1
peer-observer>    Compiling zerofrom v0.1.4
peer-observer>    Compiling tokio-macros v2.6.0
peer-observer>    Compiling futures-macro v0.3.31
peer-observer>    Compiling thiserror-impl v1.0.48
peer-observer>    Compiling equivalent v1.0.1
peer-observer>    Compiling prettyplease v0.2.25
peer-observer>    Compiling futures-task v0.3.31
peer-observer>    Compiling regex-syntax v0.8.6
peer-observer>    Compiling slab v0.4.11
peer-observer>    Compiling futures-util v0.3.31
peer-observer>    Compiling yoke v0.7.4
peer-observer>    Compiling indexmap v2.0.0
peer-observer>    Compiling bzip2 v0.4.4
peer-observer>    Compiling prost v0.14.1
peer-observer>    Compiling xattr v1.6.1
peer-observer>    Compiling thiserror-impl v2.0.12
peer-observer>    Compiling zerovec v0.10.4
peer-observer>    Compiling regex-automata v0.4.13
peer-observer>    Compiling sct v0.7.1
peer-observer>    Compiling rustls-webpki v0.101.7
peer-observer>    Compiling lock_api v0.4.10
peer-observer>    Compiling rand_core v0.9.3
peer-observer>    Compiling flate2 v1.1.5
peer-observer>    Compiling filetime v0.2.26
peer-observer>    Compiling utf8parse v0.2.1
peer-observer>    Compiling base64 v0.21.7
peer-observer>    Compiling fastrand v2.0.0
peer-observer>    Compiling webpki-roots v0.25.4
peer-observer>    Compiling fixedbitset v0.4.2
peer-observer>    Compiling fnv v1.0.7
peer-observer>    Compiling byteorder v1.5.0
peer-observer>    Compiling parking_lot_core v0.9.8
peer-observer>    Compiling bech32 v0.11.0
peer-observer>    Compiling rustls v0.23.23
peer-observer>    Compiling zip v0.6.6
peer-observer>    Compiling rustls-webpki v0.102.8
peer-observer>    Compiling petgraph v0.6.4
peer-observer>    Compiling bitcoin_hashes v0.14.0
peer-observer>    Compiling tempfile v3.8.0
peer-observer>    Compiling tar v0.4.44
peer-observer>    Compiling bitcoin-units v0.1.2
peer-observer>    Compiling tokio v1.50.0
peer-observer>    Compiling tinystr v0.7.6
peer-observer>    Compiling icu_collections v1.5.0
peer-observer>    Compiling bitreq v0.3.1 (https://github.com/0xb10c/corepc?rev=b777fa7160c7b97e1e845e771953a158233660cd#b777fa71)
peer-observer>    Compiling base58ck v0.1.0
peer-observer>    Compiling anstyle-parse v0.2.3
peer-observer>    Compiling regex v1.12.2
peer-observer>    Compiling prost-types v0.14.1
peer-observer>    Compiling rand_core v0.6.4
peer-observer>    Compiling rand_chacha v0.9.0
peer-observer>    Compiling secp256k1 v0.29.0
peer-observer>    Compiling icu_locid v1.5.0
peer-observer>    Compiling security-framework-sys v2.12.1
peer-observer>    Compiling icu_provider v1.5.0
peer-observer>    Compiling core-foundation v0.9.4
peer-observer>    Compiling aho-corasick v1.0.5
peer-observer>    Compiling colorchoice v1.0.0
peer-observer>    Compiling subtle v2.6.1
peer-observer>    Compiling anstyle-query v1.0.2
peer-observer>    Compiling multimap v0.8.3
peer-observer>    Compiling time-core v0.1.8
peer-observer>    Compiling percent-encoding v2.3.1
peer-observer>    Compiling icu_locid_transform v1.5.0
peer-observer>    Compiling bitflags v1.3.2
peer-observer>    Compiling base64 v0.22.1
peer-observer>    Compiling protobuf v3.7.2
peer-observer>    Compiling num-conv v0.2.0
peer-observer>    Compiling zeroize v1.8.1
peer-observer>    Compiling powerfmt v0.2.0
peer-observer>    Compiling scopeguard v1.2.0
peer-observer>    Compiling portable-atomic v1.9.0
peer-observer>    Compiling anstyle v1.0.10
peer-observer>    Compiling deranged v0.5.4
peer-observer>    Compiling icu_properties v1.5.1
peer-observer>    Compiling anstream v0.6.13
peer-observer>    Compiling prost-build v0.14.1
peer-observer>    Compiling time-macros v0.2.27
peer-observer>    Compiling jsonrpc v0.19.0 (https://github.com/0xb10c/corepc?rev=b777fa7160c7b97e1e845e771953a158233660cd#b777fa71)
peer-observer>    Compiling icu_normalizer v1.5.0
peer-observer>    Compiling idna_adapter v1.2.0
peer-observer>    Compiling idna v1.0.3
peer-observer>    Compiling security-framework v2.10.0
peer-observer>    Compiling corepc-types v0.11.0 (https://github.com/0xb10c/corepc?rev=b777fa7160c7b97e1e845e771953a158233660cd#b777fa71)
peer-observer>    Compiling form_urlencoded v1.2.1
peer-observer>    Compiling rand v0.9.2
peer-observer>    Compiling rand_chacha v0.3.1
peer-observer>    Compiling corepc-node v0.11.0 (https://github.com/0xb10c/corepc?rev=b777fa7160c7b97e1e845e771953a158233660cd#b777fa71)
peer-observer>    Compiling protobuf-support v3.7.2
peer-observer>    Compiling tracing-attributes v0.1.30
peer-observer>    Compiling pin-project-internal v1.1.10
peer-observer>    Compiling rustls-pemfile v2.2.0
peer-observer>    Compiling num_threads v0.1.7
peer-observer>    Compiling tracing-core v0.1.34
peer-observer>    Compiling strsim v0.11.1
peer-observer>    Compiling prometheus v0.14.0
peer-observer>    Compiling clap_lex v0.7.4
peer-observer>    Compiling tracing v0.1.41
peer-observer>    Compiling clap_builder v4.5.44
peer-observer>    Compiling time v0.3.47
peer-observer>    Compiling pin-project v1.1.10
peer-observer>    Compiling rustls-native-certs v0.7.3
peer-observer>    Compiling parking_lot v0.12.1
peer-observer>    Compiling rand v0.8.5
peer-observer>    Compiling url v2.5.3
peer-observer>    Compiling tokio-rustls v0.26.2
peer-observer>    Compiling tokio-util v0.7.15
peer-observer>    Compiling tokio-stream v0.1.17
peer-observer>    Compiling shared v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/shared)
peer-observer>    Compiling futures-executor v0.3.31
peer-observer>    Compiling clap_derive v4.5.45
peer-observer>    Compiling serde_repr v0.1.19
peer-observer>    Compiling which v3.1.1
peer-observer>    Compiling colored v3.1.1
peer-observer>    Compiling lazy_static v1.5.0
peer-observer>    Compiling simple_logger v5.2.0
peer-observer>    Compiling async-nats v0.46.0
peer-observer>    Compiling futures v0.3.31
peer-observer>    Compiling clap v4.5.45
peer-observer>    Compiling base32 v0.5.1
peer-observer>    Compiling version_check v0.9.4
peer-observer>    Compiling typenum v1.17.0
peer-observer>    Compiling crossbeam-utils v0.8.21
peer-observer>    Compiling generic-array v0.14.7
peer-observer>    Compiling httparse v1.8.0
peer-observer>    Compiling cpufeatures v0.2.9
peer-observer>    Compiling http v1.1.0
peer-observer>    Compiling utf-8 v0.7.6
peer-observer>    Compiling data-encoding v2.6.0
peer-observer>    Compiling crossbeam-epoch v0.9.18
peer-observer>    Compiling crossbeam-deque v0.8.6
peer-observer>    Compiling crossbeam-channel v0.5.15
peer-observer>    Compiling crossbeam-queue v0.3.12
peer-observer>    Compiling csv-core v0.1.12
peer-observer>    Compiling block-buffer v0.10.4
peer-observer>    Compiling crypto-common v0.1.6
peer-observer>    Compiling csv v1.4.0
peer-observer>    Compiling digest v0.10.7
peer-observer>    Compiling crossbeam v0.8.4
peer-observer>    Compiling sha1 v0.10.6
peer-observer>    Compiling tungstenite v0.27.0
peer-observer>    Compiling tokio-tungstenite v0.27.0
peer-observer>    Compiling corepc-client v0.11.0 (https://github.com/0xb10c/corepc?rev=b777fa7160c7b97e1e845e771953a158233660cd#b777fa71)
peer-observer>    Compiling rpc-extractor v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/extractors/rpc)
peer-observer>    Compiling logger v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/tools/logger)
peer-observer>    Compiling log-extractor v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/extractors/log)
peer-observer>    Compiling p2p-extractor v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/extractors/p2p)
peer-observer>    Compiling metrics v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/tools/metrics)
peer-observer>    Compiling websocket v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/tools/websocket)
peer-observer>    Compiling connectivity-check v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/tools/connectivity-check)
peer-observer>     Finished `release` profile [optimized] target(s) in 1m 24s
peer-observer> Executing cargoInstallPostBuildHook
peer-observer> Finished cargoInstallPostBuildHook
peer-observer> Finished cargoBuildHook
peer-observer> buildPhase completed in 1 minutes 25 seconds
peer-observer> Running phase: checkPhase
peer-observer> Executing cargoCheckHook
peer-observer> cargoCheckHook flags: -j 11 --profile release --target aarch64-apple-darwin --offline --all-features --workspace --exclude ebpf-extractor --
peer-observer>    Compiling shared v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/shared)
peer-observer>    Compiling hex v0.4.3
peer-observer>    Compiling rpc-extractor v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/extractors/rpc)
peer-observer>    Compiling metrics v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/tools/metrics)
peer-observer>    Compiling websocket v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/tools/websocket)
peer-observer>    Compiling logger v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/tools/logger)
peer-observer>    Compiling p2p-extractor v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/extractors/p2p)
peer-observer>    Compiling log-extractor v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/extractors/log)
peer-observer>    Compiling connectivity-check v0.1.0 (/private/tmp/nix-build-peer-observer.drv-0/source/tools/connectivity-check)
peer-observer>     Finished `release` profile [optimized] target(s) in 52.26s
peer-observer>      Running unittests src/main.rs (target/aarch64-apple-darwin/release/deps/connectivity_check-6c1d8644150c95ef)
peer-observer>
peer-observer> running 0 tests
peer-observer>
peer-observer> test result: ok(B. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
peer-observer>
peer-observer>      Running unittests src/lib.rs (target/aarch64-apple-darwin/release/deps/log_extractor-bd5dfcb54ab9cc71)
peer-observer>
peer-observer> running 0 tests
peer-observer>
peer-observer> test result: ok(B. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
peer-observer>
peer-observer>      Running unittests src/main.rs (target/aarch64-apple-darwin/release/deps/log_extractor-54a09996e9574d97)
peer-observer>
peer-observer> running 0 tests
peer-observer>
peer-observer> test result: ok(B. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
peer-observer>
peer-observer>      Running tests/integration.rs (target/aarch64-apple-darwin/release/deps/integration-c6caf37b036745bc)
peer-observer>
peer-observer> running 13 tests
peer-observer> test test_integration_logextractor_unknown_with_all_metadata ... ok(B
peer-observer> test test_integration_logextractor_unknown_with_category ... ok(B
peer-observer> test test_integration_logextractor_unknown_with_threadname_and_category ... ok(B
peer-observer> test test_integration_logextractor_block_checked has been running for over 60 seconds
peer-observer> test test_integration_logextractor_block_connected has been running for over 60 seconds
peer-observer> test test_integration_logextractor_extralogging has been running for over 60 seconds
peer-observer> test test_integration_logextractor_log_events has been running for over 60 seconds
peer-observer> test test_integration_logextractor_logtimemicros has been running for over 60 seconds
peer-observer> test test_integration_logextractor_mutated_block_bad_txnmrklroot has been running for over 60 seconds
peer-observer> test test_integration_logextractor_mutated_block_bad_witness_nonce_size has been running for over 60 seconds
peer-observer> test test_integration_logextractor_testsshouldtimeout has been running for over 60 seconds
peer-observer> test test_integration_logextractor_unknown_log_events has been running for over 60 seconds
peer-observer> test test_integration_logextractor_unknown_with_threadname has been running for over 60 seconds
error: interrupted by the user
```

</details>

<details>

<summary>Relevant logs from a CI run (different errors)</summary>

https://github.com/edilmedeiros/nix/actions/runs/23098597026/job/67095223718

```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5m 27s
     Running unittests src/main.rs (target/debug/deps/connectivity_check-029d77e63c6c2a4b)

running 0 tests

test result: ok(B. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/debug/deps/log_extractor-02181b69502f13a5)

running 0 tests

test result: ok(B. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/main.rs (target/debug/deps/log_extractor-001feab6e8a1debe)

running 0 tests

test result: ok(B. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/integration.rs (target/debug/deps/integration-5bb3a421747ffaab)

running 13 tests
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.Error: 
Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
test test_integration_logextractor_log_events ... FAILED(B
test test_integration_logextractor_block_connected ... FAILED(B
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
test test_integration_logextractor_extralogging ... FAILED(B
Error: Not enough file descriptors available. -1 available, 160 required.
test test_integration_logextractor_block_checked ... FAILED(B
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
test test_integration_logextractor_logtimemicros ... FAILED(B
Error: Not enough file descriptors available. -1 available, 160 required.
test test_integration_logextractor_mutated_block_bad_txnmrklroot ... FAILED(B
Error: Not enough file descriptors available. -1 available, 160 required.
test test_integration_logextractor_mutated_block_bad_witness_nonce_size ... FAILED(B
Error: Not enough file descriptors available. -1 available, 160 required.
test test_integration_logextractor_testsshouldtimeout - should panic ... FAILED(B
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
test test_integration_logextractor_unknown_log_events ... FAILED(B
Error: Not enough file descriptors available. -1 available, 160 required.
test test_integration_logextractor_unknown_with_threadname ... FAILED(B
test test_integration_logextractor_unknown_with_all_metadata ... FAILED(B
test test_integration_logextractor_unknown_with_category ... FAILED(B
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
Error: Not enough file descriptors available. -1 available, 160 required.
test test_integration_logextractor_unknown_with_threadname_and_category ... FAILED(B

failures:

---- test_integration_logextractor_log_events stdout ----
test that we receive log events
2026-03-15T00:11:08.542Z INFO  [integration] env BITCOIND_EXE=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:08.542Z INFO  [integration] exe_path=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:08.542Z INFO  [integration] Using bitcoind at '/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind'

thread 'test_integration_logextractor_log_events' (570300) panicked at extractors/log/tests/integration.rs:140:62:
called `Result::unwrap()` on an `Err` value: Failed to start the node after 5 attempts
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- test_integration_logextractor_block_connected stdout ----
test that we receive block connected log events
2026-03-15T00:11:08.542Z INFO  [integration] Running node1 with arg: -debug=validation
2026-03-15T00:11:08.542Z INFO  [integration] env BITCOIND_EXE=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:08.542Z INFO  [integration] exe_path=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:08.542Z INFO  [integration] Using bitcoind at '/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind'

thread 'test_integration_logextractor_block_connected' (570298) panicked at extractors/log/tests/integration.rs:140:62:
called `Result::unwrap()` on an `Err` value: Failed to start the node after 5 attempts

---- test_integration_logextractor_extralogging stdout ----
test that we can parse -logthreadnames=1 and -logsourcelocations=1 lines too
2026-03-15T00:11:08.542Z INFO  [integration] Running node1 with arg: -debug=validation
2026-03-15T00:11:08.542Z INFO  [integration] Running node1 with arg: -logthreadnames=1
2026-03-15T00:11:08.542Z INFO  [integration] Running node1 with arg: -logsourcelocations=1
2026-03-15T00:11:08.542Z INFO  [integration] Running node1 with arg: -logips=1
2026-03-15T00:11:08.542Z INFO  [integration] Running node1 with arg: -logtimemicros=1
2026-03-15T00:11:08.542Z INFO  [integration] env BITCOIND_EXE=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:08.542Z INFO  [integration] exe_path=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:08.542Z INFO  [integration] Using bitcoind at '/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind'

thread 'test_integration_logextractor_extralogging' (570299) panicked at extractors/log/tests/integration.rs:140:62:
called `Result::unwrap()` on an `Err` value: Failed to start the node after 5 attempts

---- test_integration_logextractor_block_checked stdout ----
test that we receive block checked log events
2026-03-15T00:11:08.542Z INFO  [integration] Running node1 with arg: -debug=validation
2026-03-15T00:11:08.542Z INFO  [integration] env BITCOIND_EXE=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:08.542Z INFO  [integration] exe_path=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:08.542Z INFO  [integration] Using bitcoind at '/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind'

thread 'test_integration_logextractor_block_checked' (570297) panicked at extractors/log/tests/integration.rs:140:62:
called `Result::unwrap()` on an `Err` value: Failed to start the node after 5 attempts

---- test_integration_logextractor_logtimemicros stdout ----
test that we can parse -logtimemicros timestamps
2026-03-15T00:11:33.963Z INFO  [integration] Running node1 with arg: -logtimemicros=1
2026-03-15T00:11:33.963Z INFO  [integration] env BITCOIND_EXE=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:33.963Z INFO  [integration] exe_path=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:33.963Z INFO  [integration] Using bitcoind at '/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind'

thread 'test_integration_logextractor_logtimemicros' (571480) panicked at extractors/log/tests/integration.rs:140:62:
called `Result::unwrap()` on an `Err` value: Failed to start the node after 5 attempts

---- test_integration_logextractor_mutated_block_bad_txnmrklroot stdout ----
test that we receive block mutated log events (bad-txnmrklroot)
2026-03-15T00:11:33.964Z INFO  [integration] Running node1 with arg: -debug=validation
2026-03-15T00:11:33.964Z INFO  [integration] env BITCOIND_EXE=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:33.964Z INFO  [integration] exe_path=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:33.964Z INFO  [integration] Using bitcoind at '/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind'

thread 'test_integration_logextractor_mutated_block_bad_txnmrklroot' (571482) panicked at extractors/log/tests/integration.rs:140:62:
called `Result::unwrap()` on an `Err` value: Failed to start the node after 5 attempts

---- test_integration_logextractor_mutated_block_bad_witness_nonce_size stdout ----
test that we receive block mutated log events (bad-witness-nonce-size)
2026-03-15T00:11:34.212Z INFO  [integration] Running node1 with arg: -debug=validation
2026-03-15T00:11:34.212Z INFO  [integration] env BITCOIND_EXE=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:34.212Z INFO  [integration] exe_path=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:34.212Z INFO  [integration] Using bitcoind at '/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind'

thread 'test_integration_logextractor_mutated_block_bad_witness_nonce_size' (571484) panicked at extractors/log/tests/integration.rs:140:62:
called `Result::unwrap()` on an `Err` value: Failed to start the node after 5 attempts

---- test_integration_logextractor_testsshouldtimeout stdout ----
test that we timeout long running tests
2026-03-15T00:11:34.413Z INFO  [integration] env BITCOIND_EXE=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:34.414Z INFO  [integration] exe_path=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:34.414Z INFO  [integration] Using bitcoind at '/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind'

thread 'test_integration_logextractor_testsshouldtimeout' (571490) panicked at extractors/log/tests/integration.rs:140:62:
called `Result::unwrap()` on an `Err` value: Failed to start the node after 5 attempts
note: panic did not contain expected string
      panic message: "called `Result::unwrap()` on an `Err` value: Failed to start the node after 5 attempts"
 expected substring: "timed out waiting for check() to complete"
---- test_integration_logextractor_unknown_log_events stdout ----
test that we receive unknown log events
2026-03-15T00:11:59.582Z INFO  [integration] env BITCOIND_EXE=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:59.582Z INFO  [integration] exe_path=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:59.582Z INFO  [integration] Using bitcoind at '/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind'

thread 'test_integration_logextractor_unknown_log_events' (572731) panicked at extractors/log/tests/integration.rs:140:62:
called `Result::unwrap()` on an `Err` value: Failed to start the node after 5 attempts

---- test_integration_logextractor_unknown_with_threadname stdout ----
test that we receive unknown log events with threadname
2026-03-15T00:12:00.100Z INFO  [integration] Running node1 with arg: -logthreadnames=1
2026-03-15T00:12:00.100Z INFO  [integration] env BITCOIND_EXE=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:12:00.100Z INFO  [integration] exe_path=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:12:00.100Z INFO  [integration] Using bitcoind at '/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind'

thread 'test_integration_logextractor_unknown_with_threadname' (572752) panicked at extractors/log/tests/integration.rs:140:62:
called `Result::unwrap()` on an `Err` value: Failed to start the node after 5 attempts

---- test_integration_logextractor_unknown_with_all_metadata stdout ----
test that we receive unknown log events with all metadata
2026-03-15T00:11:59.752Z INFO  [integration] Running node1 with arg: -logthreadnames=1
2026-03-15T00:11:59.752Z INFO  [integration] Running node1 with arg: -logsourcelocations=1
2026-03-15T00:11:59.752Z INFO  [integration] Running node1 with arg: -debug=net
2026-03-15T00:11:59.752Z INFO  [integration] env BITCOIND_EXE=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:59.752Z INFO  [integration] exe_path=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:59.752Z INFO  [integration] Using bitcoind at '/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind'

thread 'test_integration_logextractor_unknown_with_all_metadata' (572733) panicked at extractors/log/tests/integration.rs:140:62:
called `Result::unwrap()` on an `Err` value: Failed to start the node after 5 attempts

---- test_integration_logextractor_unknown_with_category stdout ----
test that we receive unknown log events with category
2026-03-15T00:11:59.930Z INFO  [integration] Running node1 with arg: -debug=net
2026-03-15T00:11:59.930Z INFO  [integration] env BITCOIND_EXE=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:59.930Z INFO  [integration] exe_path=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:11:59.930Z INFO  [integration] Using bitcoind at '/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind'

thread 'test_integration_logextractor_unknown_with_category' (572735) panicked at extractors/log/tests/integration.rs:140:62:
called `Result::unwrap()` on an `Err` value: Failed to start the node after 5 attempts

---- test_integration_logextractor_unknown_with_threadname_and_category stdout ----
test that we receive unknown log events with threadname and category
2026-03-15T00:12:25.385Z INFO  [integration] Running node1 with arg: -logthreadnames=1
2026-03-15T00:12:25.385Z INFO  [integration] Running node1 with arg: -debug=net
2026-03-15T00:12:25.385Z INFO  [integration] env BITCOIND_EXE=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:12:25.385Z INFO  [integration] exe_path=Ok("/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind")
2026-03-15T00:12:25.385Z INFO  [integration] Using bitcoind at '/nix/store/clj23zq7vr8mnp7rsyyyvm2d4gfs3py3-bitcoind-30.2/bin/bitcoind'

thread 'test_integration_logextractor_unknown_with_threadname_and_category' (574797) panicked at extractors/log/tests/integration.rs:140:62:
called `Result::unwrap()` on an `Err` value: Failed to start the node after 5 attempts


failures:
    test_integration_logextractor_block_checked
    test_integration_logextractor_block_connected
    test_integration_logextractor_extralogging
    test_integration_logextractor_log_events
    test_integration_logextractor_logtimemicros
    test_integration_logextractor_mutated_block_bad_txnmrklroot
    test_integration_logextractor_mutated_block_bad_witness_nonce_size
    test_integration_logextractor_testsshouldtimeout
    test_integration_logextractor_unknown_log_events
    test_integration_logextractor_unknown_with_all_metadata
    test_integration_logextractor_unknown_with_category
    test_integration_logextractor_unknown_with_threadname
    test_integration_logextractor_unknown_with_threadname_and_category

test result: FAILED(B. 0 passed; 13 failed; 0 ignored; 0 measured; 0 filtered out; finished in 102.21s

error: test failed, to rerun pass `-p log-extractor --test integration`
```

</details>

2. `ckpool`, `stratum-observer`, and `mainnet-observer-backend` won't build on darwin. Deserves some additional investigation.

Closes #315.