### PR TITLE
change: enable mainnet- and stratum-observer in macOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,12 @@ jobs:
         sudo docker image prune --all --force
         sudo docker builder prune -a
     - run: df -h
+    # Otherwise builds inherit RLIMIT_NOFILE=unlimited, which bitcoind
+    # truncates to -1 when casting to int, failing tests that spawn a node.
+    # Run before install-nix-action so nix-daemon inherits the capped limit.
+    - name: Cap launchd maxfiles on macOS
+      if: startsWith(matrix.runsOn, 'macos-')
+      run: sudo launchctl limit maxfiles 1024 524288
     - name: Install nix
       uses: cachix/install-nix-action@v31
       with:

--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,9 @@
 { pkgs ? import <nixpkgs> { } }:
 let
-  linuxOnlyPkgs = pkgs.lib.attrsets.optionalAttrs pkgs.stdenv.hostPlatform.isLinux
-    {
-      # TODO: These aren't strictly linux-specific, but the build is failing on darwin.
-      ckpool = pkgs.callPackage ./pkgs/ckpool { };
-      stratum-observer = pkgs.callPackage ./pkgs/stratum-observer { };
-      mainnet-observer-backend = (pkgs.callPackage ./pkgs/mainnet-observer { }).backend;
-    };
+  # ckpool uses clock_nanosleep (librt) and /proc/cpuinfo, both Linux-only.
+  linuxOnlyPkgs = pkgs.lib.attrsets.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+    ckpool = pkgs.callPackage ./pkgs/ckpool { };
+  };
   allPlatformsPkgs = {
     addrman-observer = pkgs.callPackage ./pkgs/addrman-observer { };
     asmap-data = pkgs.callPackage ./pkgs/asmap-data { };
@@ -17,8 +14,10 @@ let
     fork-observer = pkgs.callPackage ./pkgs/fork-observer { };
     github-metadata-backup = pkgs.callPackage ./pkgs/github-metadata-backup { };
     github-metadata-mirror = pkgs.callPackage ./pkgs/github-metadata-mirror { };
+    mainnet-observer-backend = (pkgs.callPackage ./pkgs/mainnet-observer { }).backend;
     miningpool-observer = pkgs.callPackage ./pkgs/miningpool-observer { };
     peer-observer = pkgs.callPackage ./pkgs/peer-observer { };
+    stratum-observer = pkgs.callPackage ./pkgs/stratum-observer { };
   };
 in
   allPlatformsPkgs // linuxOnlyPkgs

--- a/pkgs/peer-observer/default.nix
+++ b/pkgs/peer-observer/default.nix
@@ -61,11 +61,6 @@ rustPlatform.buildRustPackage rec {
   BITCOIND_EXE = "${pkgs.bitcoind}/bin/bitcoind";
   NATS_SERVER_BINARY="${pkgs.nats-server}/bin/nats-server";
 
-  # Avoid RLIMIT_NOFILE=unlimited overflowing to -1 in bitcoind on macOS.
-  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    ulimit -n 1024
-  '';
-
   meta = {
     description = "Hooks into Bitcoin Core to observe how our peers interact with us.";
   };


### PR DESCRIPTION
In macOS CI set the ulimit to 1024, as `unlimited` is treated as -1 by bitcoind causing tests using bitcoind to fail.

`ckpool` is linux-only.

Closes https://github.com/0xB10C/nix/issues/347