### PR TITLE
fix: correctly create archiver tempfiles 

### DIFF
--- a/modules/peer-observer/default.nix
+++ b/modules/peer-observer/default.nix
@@ -290,7 +290,8 @@ in {
 
     systemd.tmpfiles.rules = [
       "d '/var/lib/peer-observer/' 0770 'peerobserver' 'peerobserver' - -"
-      (lib.optionals cfg.tools.archiver.enable "d '${cfg.tools.archiver.outputDir}' 0770 'peerobserver' 'peerobserver' - -")
+    ] ++ lib.optionals cfg.tools.archiver.enable [
+      "d '${cfg.tools.archiver.outputDir}' 0770 'peerobserver' 'peerobserver' - -"
     ];
 
     # before we can start the peer-observer, wait until the PID file has been created by bitcoind


### PR DESCRIPTION
error: A definition for option nodes.node1.systemd.tmpfiles.rules."[definition 1-entry 2]"' is not of type string'. Definition values:
 - In `/nix/store/f35b333bk14rl6cbd07j507vqinq6v85-source/modules/peer-observer': [ ]