### PR TITLE
misc Github metdata data mirror and backup things

### DIFF
--- a/modules/github-metadata-backup/default.nix
+++ b/modules/github-metadata-backup/default.nix
@@ -208,6 +208,8 @@ in {
           ${ lib.concatMapStringsSep "\n" (gitRemote: ''
             # ${gitRemote.name}
             ${pkgs.git}/bin/git -C ${cfg.destination} remote add ${gitRemote.name} ${gitRemote.remote}
+            echo "pulling ${cfg.owner}:${cfg.repository} (${gitRemote.remote})"
+            ${pkgs.git}/bin/git -C ${cfg.destination} -c credential.helper='!f() { sleep 1; echo "username=${gitRemote.user}"; echo "password=$(cat ${gitRemote.tokenFile})"; }; f' pull ${gitRemote.name} master --rebase
             echo "pushing ${cfg.owner}:${cfg.repository} backup to remote '${gitRemote.name}' (${gitRemote.remote})"
             ${pkgs.git}/bin/git -C ${cfg.destination} -c credential.helper='!f() { sleep 1; echo "username=${gitRemote.user}"; echo "password=$(cat ${gitRemote.tokenFile})"; }; f' push --set-upstream ${gitRemote.name} master
             '') cfg.pushToRemotes }

--- a/modules/github-metadata-mirror/default.nix
+++ b/modules/github-metadata-mirror/default.nix
@@ -129,6 +129,7 @@ in {
             --owner ${escapeShellArg instanceCfg.owner} \
             --repository ${escapeShellArg instanceCfg.repository} \
             --base-url ${escapeShellArg instanceCfg.siteBaseURL} \
+	    --markdown
             ${optionalString (instanceCfg.siteFooter != "") "--footer ${escapeShellArg instanceCfg.siteFooter}"}
 
           echo "Deploying to ${cfg.wwwDir}/${instanceName}"


### PR DESCRIPTION
- run the mirror with `--markdown` by default to generate the `index.md` files for each PR / issue
- in the git-pusher, first `git pull` before pushing