### PR TITLE
ci: don't --build in update job

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -81,7 +81,7 @@ jobs:
             git checkout -b $BRANCH
             CURRENT_HEAD=$(git log -1 --format=%H)
             # HACK: "... || true" to avoid failing when no update is avaliable
-            nix-shell -p nix-update --run "nix-update --flake --commit --build --version=branch ${{ matrix.package }} || true"
+            nix-shell -p nix-update --run "nix-update --flake --commit --version=branch ${{ matrix.package }} || true"
             NEW_HEAD=$(git log -1 --format=%H)
 
             if [ "$CURRENT_HEAD" = "$NEW_HEAD" ]; then


### PR DESCRIPTION
As a broken update will always fail to build, and we never get a PR for it. Rather, we want a build failure in the PR.

This causes some broken packages not updating.