### PR TITLE
init: samply at unstable-2026-05-13

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -20,6 +20,7 @@ let
     mainnet-observer-backend = (pkgs.callPackage ./pkgs/mainnet-observer { }).backend;
     miningpool-observer = pkgs.callPackage ./pkgs/miningpool-observer { };
     peer-observer = pkgs.callPackage ./pkgs/peer-observer { };
+    samply = pkgs.callPackage ./pkgs/samply { };
     stratum-observer = pkgs.callPackage ./pkgs/stratum-observer { };
   };
 in

--- a/pkgs/samply/default.nix
+++ b/pkgs/samply/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "samply";
+  version = "0.13.1-unstable-2026-05-13";
+
+  src = fetchFromGitHub {
+    owner = "mstange";
+    repo = "samply";
+    rev = "d31a3e9ed59f06d309d6984455c824a03a15f081";
+    hash = "sha256-wGYN38owi5ryz9bQX5BOD7D91eYxUE9R7nsSXGIyiLM=";
+  };
+
+  cargoHash = "sha256-NFctaIv1bAnW62yE030HJRihVzidabrK3DWDZnxt3Zg=";
+
+  meta = {
+    description = "Command line profiler for macOS and Linux";
+    homepage = "https://github.com/mstange/samply";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = [ ];
+    mainProgram = "samply";
+  };
+})


### PR DESCRIPTION
While the latest release of https://github.com/mstange/samply is packaged in nixpkgs, this release is over a year old. Building on master here is potentially more unstable, but gives access to the newest features.