### PR TITLE
change: passthrough peer-observer static files

### DIFF
--- a/pkgs/peer-observer/default.nix
+++ b/pkgs/peer-observer/default.nix
@@ -66,13 +66,17 @@ rustPlatform.buildRustPackage rec {
   BITCOIND_EXE = "${pkgs.bitcoind}/bin/bitcoind";
   BITCOIN_NODE_EXE = "${pkgs.bitcoind}/libexec/bitcoin-node";
   NATS_SERVER_BINARY="${pkgs.nats-server}/bin/nats-server";
+  
+  passthru = {
+    # directory with the Grafana dashboards of the metrics tool
+    metrics-dashboards = "${src}/tools/metrics/dashboards";
+    # directory with the Prometheus rules of the metrics tool
+    metrics-prometheus-rules = "${src}/tools/metrics/prometheus";
+    # directory with the Websocket www pages
+    websocket-www-pages = "${src}/tools/websocket/www";
+  };
 
   meta = {
     description = "Hooks into Bitcoin Core to observe how our peers interact with us.";
   };
-
-  postInstall = ''
-    cp -r $src/tools/metrics/dashboards $out
-    cp -r $src/tools/websocket/www $out/websocket-www
-  '';
 }


### PR DESCRIPTION
Using `postInstall` meant, that we needed to compile the rust tooling first, but that's often not needed when we just want the Grafana dashboards on webservers